### PR TITLE
fix: use pnpm in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Feel free to play around with the existing code and please leave any feedback fo
 
 2. Navigate to the repo folder in your terminal
 
-3. Run `npm install` (assuming you have npm installed. If not, please follow these instructions: https://docs.npmjs.com/downloading-and-installing-node-js-and-npm/)
+3. Run `pnpm install` (assuming you have pnpm installed. If not, please follow these instructions: https://pnpm.io/installation)
 
 4. Enter your HeyGen Enterprise API Token or Trial Token in the `.env` file. Replace `HEYGEN_API_KEY` with your API key. This will allow the Client app to generate secure Access Tokens with which to create interactive sessions.
 
@@ -21,7 +21,7 @@ Feel free to play around with the existing code and please leave any feedback fo
 
 5. (Optional) If you would like to use the OpenAI features, enter your OpenAI Api Key in the `.env` file.
 
-6. Run `npm run dev`
+6. Run `pnpm dev`
 
 ### Difference between Trial Token and Enterprise API Token
 
@@ -33,7 +33,7 @@ If you do not 'close' the interactive sessions and try to open more than 3, you 
 
 ### Starting sessions
 
-NOTE: Make sure you have enter your token into the `.env` file and run `npm run dev`.
+NOTE: Make sure you have enter your token into the `.env` file and run `pnpm dev`.
 
 To start your 'session' with a Interactive Avatar, first click the 'start' button. If your HeyGen API key is entered into the Server's .env file, then you should see our demo Interactive Avatar (Monica!) appear.
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "dev": "node_modules/next/dist/bin/next dev",
+    "dev": "next dev",
     "build": "next build",
     "start": "next start",
     "lint": "eslint . --ext .ts,.tsx -c .eslintrc.json --fix"


### PR DESCRIPTION
## Changes Made

1. Updated README.md to use pnpm commands instead of npm commands to match the existing pnpm-lock.yaml file in the repository.
2. Simplified the "dev" script in package.json to use the standard Next.js command format.

## Additional Note

I also noticed the `pnpm-lock.yaml` is version 6. Running `pnpm install` using `pnpm` version 9.12.3 locally changes the `pnpm-lock.yaml` version number to 9 as well as modifies the lock file contents. If this repo wants to suggest using `pnpm` it might be nice to specify a version of `pnpm` or update the lock file. But also totally get maybe this repo wants to actually encourage `npm` use or be agnositc