### PR TITLE
Fix default voice chat transport

### DIFF
--- a/components/InteractiveAvatar.tsx
+++ b/components/InteractiveAvatar.tsx
@@ -32,7 +32,7 @@ const DEFAULT_CONFIG: StartAvatarRequest = {
     model: ElevenLabsModel.eleven_flash_v2_5,
   },
   language: "en",
-  voiceChatTransport: VoiceChatTransport.LIVEKIT,
+  voiceChatTransport: VoiceChatTransport.WEBSOCKET,
   sttSettings: {
     provider: STTProvider.DEEPGRAM,
   },


### PR DESCRIPTION
Use websocket for voice chat by default.